### PR TITLE
fix postfix installation

### DIFF
--- a/setup.examples/postfix/etc/MailScanner/conf.d/00_mailwatch.conf
+++ b/setup.examples/postfix/etc/MailScanner/conf.d/00_mailwatch.conf
@@ -1,8 +1,8 @@
 # Example config for postfix /etc/MailScanner/conf.d/00_mailwatch.conf
 Run As User = postfix
-Run As User = mtagroup
+Run As Group = mtagroup
 MTA = postfix
-Incoming Work User = postfix
+Incoming Work User = 
 Incoming Work Group = mtagroup
 Incoming Work Permissions = 0660
 Detailed Spam Report = yes

--- a/setup.examples/postfix/mailwatch-postfix.sh
+++ b/setup.examples/postfix/mailwatch-postfix.sh
@@ -9,21 +9,20 @@ cp "$DIR/etc/MailScanner/conf.d/00_mailwatch.conf" /etc/MailScanner/conf.d/00_ma
 cp "$DIR/etc/postfix/header_checks" /etc/postfix/header_checks
 echo "header_checks = regexp:/etc/postfix/header_checks" >> /etc/postfix/main.cf
 
-# restart required to create hold folder (will create error message because of still missing permissions)
-service postfix start
-sleep 3
-service postfix stop
-
 # "Setting file permissions for use of postfix"
 mkdir -p /var/spool/MailScanner/spamassassin/
 chown -R postfix:mtagroup /var/spool/MailScanner/spamassassin
 chown -R postfix:postfix /var/spool/MailScanner/incoming
 chown -R postfix:postfix /var/spool/MailScanner/quarantine
 
-chown    postfix:postfix /var/spool/postfix
-chown -R postfix:mtagroup /var/spool/postfix/{incoming,hold}
+
+# restart required to create hold folder (will create error message because of still missing permissions but they can be ignored)
+service postfix start
+sleep 3
+service postfix stop
+
+chown -R postfix:"$Webuser" /var/spool/postfix/{incoming,hold}
 chmod -R g+r /var/spool/postfix/{hold,incoming}
-chown -R postfix:postfix /var/spool/postfix/{active,bounce,flush}
 
 # restart again to notice new permissions
 service postfix start


### PR DESCRIPTION
Fixes problem with postfix which causes error 
```
process /usr/lib/postfix/qmgr pid 60822 exit status 1
fatal: open active [...] permission denied
```