### PR TITLE
Setup config

### DIFF
--- a/setup.scripts/mailscanner/mailwatch-mailscanner.inc
+++ b/setup.scripts/mailscanner/mailwatch-mailscanner.inc
@@ -5,13 +5,13 @@ MailScannerTmpDir="$TmpDir/mailscanner/"
 
 function install-mailscanner() {
     logprint ""
-    if [ "$PM" == "yum" ]; then
+    if [[ "$PM" == "yum"* ]]; then
         MailScannerDownloadPath="https://s3.amazonaws.com/msv5/release/MailScanner-$MailScannerVersion.rhel.tar.gz"
-    elif [ "$PM" == "apt-get" ]; then
+    elif [[ "$PM" == "apt-get"* ]]; then
         MailScannerDownloadPath="https://s3.amazonaws.com/msv5/release/MailScanner-$MailScannerVersion.deb.tar.gz"
     fi
 
-    read -p "Install/upgrade MailScanner version $MailScannerVersion?:(y/n)[y]: " installMailScanner
+    ask "Install/upgrade MailScanner version $MailScannerVersion?:(y/n)[y]: " installMailScanner
     if [ -z $installMailScanner ] || [ "$installMailScanner" == "y" ]; then
         logprint "Starting MailScanner install"
         mkdir -p /tmp/mailwatchinstall/mailscanner

--- a/setup.scripts/mailwatch/mailwatch-setup-config.inc
+++ b/setup.scripts/mailwatch/mailwatch-setup-config.inc
@@ -49,7 +49,7 @@ function resetVariables() {
     logprint "Clean up variables"
     installMailScanner=
     WebFolder=
-    overwriteWebFolder
+    overwriteWebFolder=
     upgrading=
     SqlUser=
     SqlPwd=

--- a/setup.scripts/mailwatch/mailwatch-setup-config.inc
+++ b/setup.scripts/mailwatch/mailwatch-setup-config.inc
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+#defines if MailScanner should be installed/upgraded
+installMailScanner=
+#Path to new/old web directory
+WebFolder=
+#If WebFolder exists this confirms to overwrite it
+overwriteWebFolder
+#When WebFolder exists this will save the old conf.php, skin.css
+upgrading=
+
+#Sql settings, when not upgrading this user gets access to the MW db
+SqlUser=
+SqlPwd=
+SqlDb=
+SqlHost=
+
+#which web server shall be installed (1: apache, 2: nginx, others: skip)
+webserverSelect=
+#when skipping web server install, the permissions will be assigned to this user
+WebUser=
+
+#php install: will install/upgrade neccessary packets with system package manager
+# base php packets need for MW
+installPhp=
+# packages for use with ldap
+installLdap=
+# packages for use with rpc
+installRpc=
+
+#install mariadb-server if no sql server was found
+installMariadb=
+#sql user with rights to create the sql database and assign permissions to it (not used on upgrade)
+SqlRoot=
+#pwd for sql root user
+SqlRootPwd=
+
+#credentials for new MW admin (not used on upgrade)
+MWAdmin=
+MWAdminPwd=
+
+#confirm each installation of packages done with the package manager
+confirmPackageInstalls=
+
+function resetVariables() {
+    logprint "Clean up variables"
+    installMailScanner=
+    WebFolder=
+    overwriteWebFolder
+    upgrading=
+    SqlUser=
+    SqlPwd=
+    SqlDb=
+    SqlHost=
+    webserverSelect=
+    WebUser=
+    installPhp=
+    installLdap=
+    installRpc=
+    installMariadb=
+    SqlRoot=
+    SqlRootPwd=
+    MWAdmin=
+    MWAdminPwd=
+    confirmPackageInstalls=
+}

--- a/setup.scripts/mailwatch/mailwatch-setup-config.inc
+++ b/setup.scripts/mailwatch/mailwatch-setup-config.inc
@@ -5,7 +5,7 @@ installMailScanner=
 #Path to new/old web directory
 WebFolder=
 #If WebFolder exists this confirms to overwrite it
-overwriteWebFolder
+overwriteWebFolder=
 #When WebFolder exists this will save the old conf.php, skin.css
 upgrading=
 

--- a/setup.scripts/mailwatch/mailwatch-setup-config.inc
+++ b/setup.scripts/mailwatch/mailwatch-setup-config.inc
@@ -20,6 +20,9 @@ webserverSelect=
 #when skipping web server install, the permissions will be assigned to this user
 WebUser=
 
+#which mta to configure for MW: 1:postfix, 2:exim, 3:sendmail, 4/n/others:skip
+useMta=
+
 #php install: will install/upgrade neccessary packets with system package manager
 # base php packets need for MW
 installPhp=
@@ -54,6 +57,7 @@ function resetVariables() {
     SqlHost=
     webserverSelect=
     WebUser=
+    useMta=
     installPhp=
     installLdap=
     installRpc=

--- a/setup.scripts/mailwatch/mailwatch.inc
+++ b/setup.scripts/mailwatch/mailwatch.inc
@@ -5,6 +5,16 @@ function logprint {
     echo -e "$1" >> /root/mailwatchInstall.log
 }
 
+function ask() {
+    message="$1"
+    var="$2"
+    if [ -z "${!var}" ]; then
+        read -r -p "$message" "$var"
+    else
+        logprint "$var set by setup-config. Using that value"
+    fi
+}
+
 function detectos() {
     if cat /etc/*release | grep CentOS; then
         OS="CentOS"
@@ -49,15 +59,12 @@ function download-mailwatch() {
 function install-mailwatch() {
     ################# Copy MailWatch files and set permissions ##################
     if [ -d $WebFolder ]; then
-        read -p "Folder $WebFolder already exists. Old files except config.php and skin.css will be removed.  Do you want to continue?(y/n)[n]: " response
-        if [ -z $response ]; then
-            logprint "Stopping setup on user request"
-            exit
-        elif [ "$response" == "n" ]; then
+        ask "Folder $WebFolder already exists. Old files except config.php and skin.css will be removed.  Do you want to continue?(y/n)[n]: " overwriteWebFolder
+        if [ -z $overwriteWebFolder ] || [ "$overwriteWebFolder" == "n" ]; then
             logprint "Stopping setup on user request"
             exit
         fi
-        read -p "Are you upgrading mailwatch? Requires valid conf.php in the web files directory. (y/n)[y]" upgrading
+        ask "Are you upgrading mailwatch? Requires valid conf.php in the web files directory. (y/n)[y]" upgrading
         if [ -z $upgrading ] || [ "$upgrading" == "y" ]; then
             if [ -f "$WebFolder/conf.php" ]; then
                 IsUpgrade=1
@@ -92,19 +99,19 @@ function configure-sqlcredentials() {
     if [ "$IsUpgrade" == 0 ]; then
         logprint "Setting up sql credentials"
         #get sql credentials
-        read -p "SQL user for mailwatch[mailwatch]:" SqlUser
+        ask "SQL user for mailwatch[mailwatch]:" SqlUser
         if [ -z $SqlUser ]; then
             SqlUser="mailwatch"
         fi
-        read -p "SQL password for mailwatch[mailwatch]:" SqlPwd
+        ask "SQL password for mailwatch[mailwatch]:" SqlPwd
         if [ -z $SqlPwd ]; then
             SqlPwd="mailwatch"
         fi
-        read -p "SQL database for mailwatch[mailscanner]:" SqlDb
+        ask "SQL database for mailwatch[mailscanner]:" SqlDb
         if [  -z $SqlDb ]; then
             SqlDb="mailscanner"
         fi
-        read -p "SQL host of database[localhost]:" SqlHost
+        ask "SQL host of database[localhost]:" SqlHost
         if [ -z $SqlHost ]; then
             SqlHost="localhost"
         fi

--- a/setup.scripts/mailwatch/mailwatch.inc
+++ b/setup.scripts/mailwatch/mailwatch.inc
@@ -16,9 +16,14 @@ function ask() {
 }
 
 function detectos() {
+    if [ -z $confirmPackageInstalls ] && [ "$confirmPackageInstalls" == "y"]; then
+        packageConfirm=" -y "
+        #may add export DEBIAN_FRONTEND=noninteractive (for deb based) so that the install is completely unattanded
+        #(see https://serverfault.com/questions/143968/automate-the-installation-of-postfix-on-ubuntu)
+    fi
     if cat /etc/*release | grep CentOS; then
         OS="CentOS"
-        PM="yum"
+        PM="yum $packageConfirm"
         #find OS version
         if cat /etc/*release | grep 5; then
             OSVersion="5"
@@ -29,13 +34,13 @@ function detectos() {
         fi
     elif cat /etc/*release | grep ^NAME | grep Red; then
         OS="RedHat"
-        PM="yum"
+        PM="yum $packageConfirm"
     elif cat /etc/*release | grep ^NAME | grep Fedora; then
         OS="Fedora"
-        PM="yum"
+        PM="yum $packageConfirm"
     elif cat /etc/*release | grep -i Debian; then
         OS="Debian"
-        PM="apt-get"
+        PM="apt-get $packageConfirm"
     else
         echo "OS NOT SUPPORTED - Please perform a manual install"
         exit 1;

--- a/setup.scripts/mailwatch/mailwatch.inc
+++ b/setup.scripts/mailwatch/mailwatch.inc
@@ -16,7 +16,7 @@ function ask() {
 }
 
 function detectos() {
-    if [ -z $confirmPackageInstalls ] && [ "$confirmPackageInstalls" == "y"]; then
+    if ! [ -z "$confirmPackageInstalls" ] && [ "$confirmPackageInstalls" == "y" ]; then
         packageConfirm=" -y "
         #may add export DEBIAN_FRONTEND=noninteractive (for deb based) so that the install is completely unattanded
         #(see https://serverfault.com/questions/143968/automate-the-installation-of-postfix-on-ubuntu)

--- a/setup.scripts/mysql/mailwatch-mysql.inc
+++ b/setup.scripts/mysql/mailwatch-mysql.inc
@@ -35,11 +35,11 @@ function configure-mysql() {
     if [ "$IsUpgrade" == 1 ]; then
         logprint "Not creating sql db because we are running an upgrade"
     elif [ "$mysqlInstalled" == "1" ]; then
-        ask "Root sql user (with rights to create db)[root]:" SqlRoot
+        ask "Root sql user (with rights to create db)[root]: " SqlRoot
         if [ -z $SqlRoot ]; then
             SqlRoot="root"
         fi
-        ask "Passwort for root sql user" SqlRootPwd
+        ask "Passwort for root sql user: " SqlRootPwd
         logprint "Creating sql database and setting permission."
         mysql -u $SqlRoot -p$SqlRootPwd < "$MailWatchTmpDir/create.sql"
         mysql -u $SqlRoot -p$SqlRootPwd --execute="GRANT ALL ON $SqlDb.* TO $SqlUser@localhost IDENTIFIED BY '$SqlPwd'; GRANT FILE ON *.* TO $SqlUser@localhost IDENTIFIED BY '$SqlPwd'; FLUSH PRIVILEGES"

--- a/setup.scripts/mysql/mailwatch-mysql.inc
+++ b/setup.scripts/mysql/mailwatch-mysql.inc
@@ -5,8 +5,8 @@ function install-mysql() {
     ############ Configure mysql server ################
     logprint ""
     if ! ( type "mysqld" > /dev/null 2>&1 ) ; then
-        read -p "No mysql server found. Do you want to install mariadb as sql server?(y/n)[y]: " response
-        if [ -z $response ] || [ $response == "y" ]; then
+        ask "No mysql server found. Do you want to install mariadb as sql server?(y/n)[y]: " installMariadb
+        if [ -z $installMariadb ] || [ $installMariadb == "y" ]; then
             logprint "Start install of mariadb"
             if [ $OS == "CentOS" ]; then
                 logprint "Adding MariaDB 10.1 Repo"
@@ -35,16 +35,18 @@ function configure-mysql() {
     if [ "$IsUpgrade" == 1 ]; then
         logprint "Not creating sql db because we are running an upgrade"
     elif [ "$mysqlInstalled" == "1" ]; then
-        read -p "Root sql user (with rights to create db)[root]:" SqlRoot
+        ask "Root sql user (with rights to create db)[root]:" SqlRoot
         if [ -z $SqlRoot ]; then
             SqlRoot="root"
         fi
-        logprint "Creating sql database and setting permission. You now need to enter the password of the root sql user twice"
-        mysql -u $SqlRoot -p < "$MailWatchTmpDir/create.sql"
-        mysql -u $SqlRoot -p --execute="GRANT ALL ON $SqlDb.* TO $SqlUser@localhost IDENTIFIED BY '$SqlPwd'; GRANT FILE ON *.* TO $SqlUser@localhost IDENTIFIED BY '$SqlPwd'; FLUSH PRIVILEGES"
+        ask "Passwort for root sql user" SqlRootPwd
+        logprint "Creating sql database and setting permission."
+        mysql -u $SqlRoot -p$SqlRootPwd < "$MailWatchTmpDir/create.sql"
+        mysql -u $SqlRoot -p$SqlRootPwd --execute="GRANT ALL ON $SqlDb.* TO $SqlUser@localhost IDENTIFIED BY '$SqlPwd'; GRANT FILE ON *.* TO $SqlUser@localhost IDENTIFIED BY '$SqlPwd'; FLUSH PRIVILEGES"
+        SqlRootPwd=
 
-        read -p "Enter an admin user for the MailWatch web interface: " MWAdmin
-        read -p "Enter password for the admin: " MWAdminPwd
+        ask "Enter an admin user for the MailWatch web interface: " MWAdmin
+        ask "Enter password for the admin: " MWAdminPwd
         logprint "Create MailWatch web gui admin"
         mysql -u $SqlUser -p$SqlPwd $SqlDb --execute="REPLACE INTO users SET username = '$MWAdmin', password = MD5('$MWAdminPwd'), fullname = 'Admin', type = 'A';"
     else

--- a/setup.scripts/php/mailwatch-php.inc
+++ b/setup.scripts/php/mailwatch-php.inc
@@ -2,7 +2,7 @@
 
 function install-php-core() {
     logprint ""
-    read -p "MailWatch requires the php packages php php-gd and php-mysqlnd. Do you want to install them if missing?(y/n)[y]: " installPhp
+    ask "MailWatch requires the php packages php php-gd and php-mysqlnd. Do you want to install them if missing?(y/n)[y]: " installPhp
     if [ -z $installPhp ] || [ "$installPhp" == "y" ]; then
         logprint "Installing required php packages"
         # since debian 9 and ubuntu 16 packages are php php-gd etc. instead of php5.
@@ -24,7 +24,7 @@ function install-php-core() {
 
 function install-php-ldap() {
     logprint ""
-    read -p "Do you want to use LDAP for user authentication (requires php-ldap)? (y/n)[y]: " installLdap
+    ask "Do you want to use LDAP for user authentication (requires php-ldap)? (y/n)[y]: " installLdap
     if [ -z $installLdap ] || [ "$installLdap" == "y" ]; then
         logprint "Installing required php-ldap package"
         if [ "$OS" == "Debian" ]; then
@@ -43,7 +43,7 @@ function install-php-ldap() {
 
 function install-php-rpc() {
     logprint ""
-    read -p "Do you want to use RPC for this server (requires php-xml)? (y/n)[y]: " installRpc
+    ask "Do you want to use RPC for this server (requires php-xml)? (y/n)[y]: " installRpc
     if [ -z $installRpc ] || [ "$installLdap" == "y" ]; then
         logprint "Installing required php-xml package"
         if [ "$OS" == "Debian" ]; then

--- a/setup.sh
+++ b/setup.sh
@@ -101,8 +101,8 @@ case $WebServer in
     "apache")
         logprint "Creating config for apache"
         "$InstallFilesFolder/setup.scripts/apache/mailwatch-apache.sh" "$WebFolder"
-        if [ $PM == "yum" ]; then
-            Webuser="nginx"
+        if [[ "$PM" == "yum"* ]]; then
+            Webuser="apache"
         else
             Webuser="www-data"
         fi
@@ -110,7 +110,7 @@ case $WebServer in
         ;;
     "nginx")
        #TODO
-        if [ $PM == "yum" ]; then
+        if [[ "$PM" == "yum"* ]]; then
             Webuser="nginx"
         else
             Webuser="www-data"

--- a/setup.sh
+++ b/setup.sh
@@ -12,6 +12,7 @@ IsUpgrade=0
 
 EndNotice=""
 
+source "$InstallFilesFolder/setup.scripts/mailwatch/mailwatch-setup-config.inc"
 source "$InstallFilesFolder/setup.scripts/mailwatch/mailwatch.inc"
 source "$InstallFilesFolder/setup.scripts/mailscanner/mailwatch-mailscanner.inc"
 source "$InstallFilesFolder/setup.scripts/mysql/mailwatch-mysql.inc"
@@ -40,7 +41,7 @@ install-mailscanner
 
 ##ask directory for web files
 logprint ""
-read -p "In what location should MailWatch be installed (web files directory)?[/var/www/html/mailscanner/]:" WebFolder
+ask "In what location should MailWatch be installed (web files directory)?[/var/www/html/mailscanner/]:" WebFolder
 if [ -z $WebFolder ]; then
     WebFolder="/var/www/html/mailscanner/"
 fi
@@ -69,11 +70,11 @@ else
     echo "2 - Nginx"
     echo "n - do not install or configure"
     echo;
-    read -r -p "Select Webserver: " response
-    if [[ $response =~ ^([nN][oO])$ ]]; then
+    ask "Select Webserver: " webserverSelect
+    if [[ $webserverSelect =~ ^([nN][oO])$ ]]; then
         #do not install or configure webserver
         WebServer="skip"
-    elif [ $response == 1 ]; then
+    elif [ $webserverSelect == 1 ]; then
         #Apache
         logprint "Installing apache"
         if [ $PM == "yum" ]; then
@@ -82,7 +83,7 @@ else
             $PM install apache2
         fi
         WebServer="apache"
-    elif [ $response == 2 ]; then
+    elif [ $webserverSelect == 2 ]; then
         #Nginx
         logprint "Installing nginx"
         $PM install nginx
@@ -120,7 +121,7 @@ case $WebServer in
     "skip")
         logprint "Skipping web server install"
         EndNotice="$EndNotice \n * you need to configure your webserver for directory $WebFolder."
-        read -p "MailWatch needs to assign permissions to the webserver user. What user is your webserver running at?: " Webuser
+        ask "MailWatch needs to assign permissions to the webserver user. What user is your webserver running at?: " Webuser
         sleep 1
         ;;
 esac
@@ -128,43 +129,29 @@ esac
 configure-mailwatch
 
 #####################apply adjustments for MTAs ########################
-PS3='Which MTA do you want to use with MailWatch? (it should already be installed):'
-options=("sendmail" "postfix" "exim" "skip")
-select opt in "${options[@]}"
-do
-    logprint "Selected mta $opt"
-    case $opt in
-        "sendmail")
-            logprint "Not yet supported"
-#TODO
-            sleep 1
-            break
-            ;;
-        "postfix")
-            logprint "Configure MailScanner for use with postfix"
-            "$InstallFilesFolder/setup.scripts/postfix/mailwatch-postfix.sh" "$Webuser"
-            sleep 1
-            break
-            ;;
-
-        "exim")
-            logprint "Configure MailScanner for use with exim"
-            "$InstallFilesFolder/setup.scripts/exim/mailwatch-exim.sh" "$Webuser"
-            sleep 1
-            break
-            ;;
-        *)
-            logprint "Not configuring mta"
-            sleep 1
-            break
-            ;;
-    esac
-done
+logprint 'Which MTA do you want to use with MailWatch? (it should already be installed):'
+ask 'MTAs: 1:postfix, 2:exim, 3:sendmail, 4/n: skip' useMta
+logprint "Selected mta $useMta"
+if [ "$useMta" == "1" ]; then
+    logprint "Configure MailScanner for use with postfix"
+    "$InstallFilesFolder/setup.scripts/postfix/mailwatch-postfix.sh" "$Webuser"
+elif [ "$useMta" == "2" ];then
+    logprint "Configure MailScanner for use with exim"
+    "$InstallFilesFolder/setup.scripts/exim/mailwatch-exim.sh" "$Webuser"
+elif [ "$useMta" == "3" ]; then
+    logprint "Sendmail is not yet supported. If you have experience with sendmail and want to help support this please contact us at https://github.com/mailwatch/mailwatch-install-script"
+    #TODO
+else
+    logprint "Not configuring mta"
+fi
+sleep 1
 
 configure-mailscanner
 
 #todo relay files
 logprint "Install finished!"
+resetVariables
+logprint ""
 logprint "Next steps you have to do are:"
 logprint "$EndNotice"
 logprint " * adjust your mta and web server configs"


### PR DESCRIPTION
Enable the configuration of the setup script by setting it in ./setup.scripts/mailwatch/mailwatch-setup-config.inc. 

With this a mostly unattended installation of MW is possible. Only the MailScanner installation (and possible default config for postfix/exim) and in case we are installing mariadb-server the mysql_secure_installation will require user interaction.

If an option in ./setup.scripts/mailwatch/mailwatch-setup-config.inc has an empty string or no value at all the user will be prompted for the option during install, else the defined value will be used.